### PR TITLE
Fixed video not playing in center on full screen

### DIFF
--- a/lib/src/player.dart
+++ b/lib/src/player.dart
@@ -110,7 +110,7 @@ class VideoPlayerState extends State<VideoPlayer> {
 			context: context,
 			builder: (_) => WillPopScope(
 				onWillPop: closeFullScreen,
-				child: Scaffold(body: VideoPlayer(controller))
+				child: Scaffold(body: Center(child: VideoPlayer(controller)))
 			)
 		);
 		controller.isFullScreen = false;


### PR DESCRIPTION
Added center widget on top of video player to make video to play on center in full screen mode.